### PR TITLE
Fix three code bugs

### DIFF
--- a/TrainModeling/Railroad.swift
+++ b/TrainModeling/Railroad.swift
@@ -62,9 +62,8 @@ class Railroad {
     //MARK: - Other
     
     public func sortTrainsByStartTime() {
-        trains = trains.sorted { (t1, t2) -> Bool in {
+        trains = trains.sorted { (t1, t2) -> Bool in
             return t1.getStartAbsoluteTime() < t2.getStartAbsoluteTime()
-            }()
         }
     }
     

--- a/TrainModeling/Settings.swift
+++ b/TrainModeling/Settings.swift
@@ -81,7 +81,9 @@ class Settings {
     }
     
     private func sortList(_ list: [(String, Float)]) -> [(String, Float)] {
-        return list.sorted { (a, b) -> Bool in { a.1 < b.1 }() }
+        return list.sorted { (a, b) -> Bool in
+            return a.1 < b.1
+        }
     }
 
     

--- a/TrainModeling/ViewController.swift
+++ b/TrainModeling/ViewController.swift
@@ -269,7 +269,7 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
         }
         
         // удаляем поезда которые добавили в массив activeTrains
-        for index in indices {
+        for index in indices.sorted(by: >) {
             trains.remove(at: index)
         }
         
@@ -286,7 +286,7 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
         }
         
         //удаляем поезда, которые достигли пунктов назначения
-        for index in indices {
+        for index in indices.sorted(by: >) {
             activeTrains.remove(at: index)
         }
         


### PR DESCRIPTION
Fix invalid Swift sorting closure syntax in `Settings` and `Railroad` and resolve an index-shift bug during array element removal in `ViewController`.

Removing elements from an array using ascending indices can lead to index-shift errors, causing elements to be skipped or crashes. Sorting indices in reverse order ensures safe and correct removal.

---
<a href="https://cursor.com/background-agent?bcId=bc-934f4d4c-782d-4bee-a290-5bd5ececc47d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-934f4d4c-782d-4bee-a290-5bd5ececc47d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

